### PR TITLE
Ensure file isn't processed before processing it

### DIFF
--- a/classes/class.ilObjOnlyOfficeGUI.php
+++ b/classes/class.ilObjOnlyOfficeGUI.php
@@ -351,7 +351,9 @@ class ilObjOnlyOfficeGUI extends ilObjectPluginGUI
 
         // Handle file upload, otherwise create new document
         if ($_POST[self::POST_VAR_FILE_SETTING] === self::OPTION_SETTING_UPLOAD) {
-            self::dic()->upload()->process();
+            if (!self::dic()->upload()->hasBeenProcessed()) {
+                self::dic()->upload()->process();
+            }
             $results = self::dic()->upload()->getResults();
             $result = end($results);
             $this->storage_service->createNewFileFromUpload($result, $a_new_object->getId());

--- a/classes/class.ilOnlyOfficeConfigGUI.php
+++ b/classes/class.ilOnlyOfficeConfigGUI.php
@@ -330,8 +330,9 @@ class ilOnlyOfficeConfigGUI extends ilPluginConfigGUI
             // Dont delete previous template
             $this->storage_service->modifyFileTemplate($prevTitle, $prevExtension, $target, $description);
         } else {
-
-            self::dic()->upload()->process();
+            if (!self::dic()->upload()->hasBeenProcessed()) {
+                self::dic()->upload()->process();
+            }
             $results = self::dic()->upload()->getResults();
             $result = end($results);
 


### PR DESCRIPTION
https://redmine.databay.de/issues/38418

Makes the code more robust by preventing double procession.