### PR TITLE
Fix PHP crash when copying course with OnlyOffice objects

### DIFF
--- a/classes/class.ilObjOnlyOffice.php
+++ b/classes/class.ilObjOnlyOffice.php
@@ -76,7 +76,7 @@ class ilObjOnlyOffice extends ilObjectPlugin
         $end_time = $_POST[ilObjOnlyOfficeGUI::POST_VAR_EDIT_LIMITED_END];
 
         if ($title == null) {
-            $title = explode('.', $_POST[ilObjOnlyOfficeGUI::POST_VAR_FILE]['name'])[0];
+            $title = isset($_POST[ilObjOnlyOfficeGUI::POST_VAR_FILE]['name']) ? $_POST[ilObjOnlyOfficeGUI::POST_VAR_FILE]['name'] : '';
             $_POST['title'] = $title;
         }
 


### PR DESCRIPTION
Set $title to an empty string if the "upload_files" key is missing from the `$_POST` array, preventing the PHP script from crashing when copying a course with OnlyOffice objects.